### PR TITLE
Few more small changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,8 +119,6 @@ module.exports = function(grunt) {
   grunt.registerTask('stop-publish', 'shell:killpublish');
   grunt.registerTask('mvn-publish', 'shell:mvnpublish');
   grunt.registerTask('mvn-author', 'shell:mvnauthor');
-  grunt.registerTask('publish-image', 'slingPost:publishImg');
-  grunt.registerTask('author-image', 'slingPost:authorImg');
   grunt.registerTask('author', ['watch:author']);
   grunt.registerTask('publish', ['watch:publish']);
   grunt.registerTask('default', ['watch']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,14 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    devUpdate: {
+      checkUpdate: {
+        options: {
+          reportUpdated: false,
+          updateType: 'report'
+        }
+      }
+    },
     shell: {
       startPublish: {
         options: {
@@ -113,6 +121,7 @@ module.exports = function(grunt) {
     grunt.config.set(['slingPost', 'publish', 'dest'], [destination]);
   });
 
+  grunt.registerTask('check', 'devUpdate');
   grunt.registerTask('start-author', 'shell:startAuthor');
   grunt.registerTask('start-publish', 'shell:startPublish');
   grunt.registerTask('stop-author', 'shell:killauthor');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,5 +121,5 @@ module.exports = function(grunt) {
   grunt.registerTask('mvn-author', 'shell:mvnauthor');
   grunt.registerTask('author', ['watch:author']);
   grunt.registerTask('publish', ['watch:publish']);
-  grunt.registerTask('default', ['watch']);
+  grunt.registerTask('default', ['watch:author']);
 };

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ I've also added a few tasks to do maven builds and start and stop instances, the
 * `grunt start-author` & `grunt start-publish` start whichever CQ instance you'd like.
 * `grunt stop-author` & `grunt stop-publish` kill the running java processes of each instance.
 
+If you’d like to ensure that the devDependencies are up-to-date run `grunt check`, which will print out a list of dependencies that can be updated.
+
 ### Notes
 
 * If you are running into EMFILE fatal errors, use `ulimit -n 10240` in the current session to boost the amount of open files allowed.
+* To verify that you’re watching the correct directories, run either of your watch tasks (`grunt author` or `grunt publish`) with the `--verbose` flag.
 * Running a watch task and a maven build may take up all of your memory, mostly for larger projects. I recommend stopping the watch tasks with `control + c` before doing a maven build.
 * If you make edits to files while not running one of the grunt tasks, the changes will be lost unless you do a maven build.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "description": "Watch files edited and automatically deploy them to CRX",
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-dev-update": "~0.4.5",
     "grunt-shell": "~0.6.4",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-sling-content": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "description": "Watch files edited and automatically deploy them to CRX",
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-dev-update": "~0.4.5",
-    "grunt-shell": "~0.6.4",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-sling-content": "~0.1.1",
+    "grunt-dev-update": "~0.4.5",
     "grunt-macreload": "~0.1.3",
-    "load-grunt-tasks": "~0.2.1",
-    "time-grunt": "~0.2.8"
+    "grunt-shell": "~0.6.4",
+    "grunt-sling-content": "~0.1.1",
+    "load-grunt-tasks": "~0.3.0",
+    "time-grunt": "~0.2.9"
   },
   "options": {
     "host": "localhost",


### PR DESCRIPTION
The most noteworthy change is the addition of grunt-dev-update and corresponding `grunt check` command to verify that the devDependencies are up-to-date. If they're not then the plugin lists which ones are old and their current version numbers. This plugin can auto-update too, but I figure it makes more sense to be notified and then update everything by hand, in the event of conflicts.
